### PR TITLE
Remove obsolete log-service config from new domains

### DIFF
--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -302,9 +302,6 @@
          <jms-service type="EMBEDDED" default-jms-host="default_JMS_host" addresslist-behavior="priority">
              <jms-host name="default_JMS_host" host="localhost" port="${JMS_PROVIDER_PORT}" admin-user-name="admin" admin-password="admin" lazy-init="true"/>
          </jms-service>
-         <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
-             <module-log-levels />
-         </log-service>
          <security-service>
              <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
                  <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile" />

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/VirtualServer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/VirtualServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -871,22 +871,27 @@ public class VirtualServer extends StandardHost implements org.glassfish.embedda
     /**
      * Configures this virtual server with the specified log file.
      *
-     * @param logFile The value of the virtual server's log-file attribute in the domain.xml
+     * @param logFile The value of the virtual server's log-file attribute in the domain.xml,
+     *            {@code null} if the attribute is not set
+     * @param logServiceFile The server log file, {@code null} if it is not known
      */
     synchronized void setLogFile(String logFile, String logLevel, String logServiceFile) {
         _logger.log(Level.CONFIG, "setLogFile(logFile={0}, logServiceFile={1})",
             new Object[] {logFile, logServiceFile});
 
-        /*
-         * Configure separate logger for this virtual server only if 'log-file' attribute of this <virtual-server> and 'file'
-         * attribute of <log-service> are different (See 6189219).
-         */
-        boolean customLog = (logFile != null && logServiceFile != null
-            && !new File(logFile).equals(new File(logServiceFile)));
+        // The log-file attribute is optional; without it this virtual server logs into the
+        // server log, wherever that currently is.
+        final String vsLogFile = logFile == null ? logServiceFile : logFile;
 
-        boolean logFileChanged = logFile != null
-            && ((fileLoggerHandler != null && !logFile.equals(fileLoggerHandler.getLogFile()))
-                || fileLoggerHandler == null);
+        /*
+         * Configure separate logger for this virtual server only if its log file and the server
+         * log file are different (See 6189219).
+         */
+        boolean customLog = vsLogFile != null && logServiceFile != null
+            && !new File(vsLogFile).equals(new File(logServiceFile));
+
+        boolean logFileChanged = fileLoggerHandler == null
+            || !fileLoggerHandler.getLogFile().equals(vsLogFile);
 
         /*
          * Exit early if the log file isn't being changed.
@@ -948,7 +953,7 @@ public class VirtualServer extends StandardHost implements org.glassfish.embedda
         }
 
         // create and add new handler
-        fileLoggerHandler = fileLoggerHandlerFactory.getHandler(logFile);
+        fileLoggerHandler = fileLoggerHandlerFactory.getHandler(vsLogFile);
         newLogger.addHandler(fileLoggerHandler);
         newLogger.setUseParentHandlers(false);
         setLogger(newLogger);

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/VirtualServer.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/VirtualServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -258,12 +258,12 @@ public interface VirtualServer extends ConfigBeanProxy, PropertyBag {
     /**
      * Gets the value of the {@code logFile} property.
      *
-     * <p>Specifies a log file for virtual-server-specific log messages. Default value is
-     * {@code ${com.sun.aas.instanceRoot}/logs/server.log}.
+     * <p>Specifies a log file for virtual-server-specific log messages. When it is not set,
+     * the virtual server logs into the server log.
      *
      * @return possible object is {@link String}
      */
-    @Attribute(defaultValue = "${com.sun.aas.instanceRoot}/logs/server.log")
+    @Attribute
     String getLogFile();
 
     /**

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/logging/UpgradeLogging.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/logging/UpgradeLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,6 +18,7 @@
 package com.sun.enterprise.admin.servermgmt.logging;
 
 import com.sun.common.util.logging.LoggingConfigImpl;
+import com.sun.common.util.logging.LoggingXMLNames;
 import com.sun.enterprise.admin.servermgmt.RepositoryConfig;
 import com.sun.enterprise.admin.servermgmt.pe.PEFileLayout;
 import com.sun.enterprise.config.serverbeans.Config;
@@ -33,6 +34,8 @@ import java.io.IOException;
 import java.lang.System.Logger;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
 
 import org.glassfish.api.admin.config.ConfigurationUpgrade;
 import org.glassfish.hk2.api.PostConstruct;
@@ -68,14 +71,29 @@ public class UpgradeLogging implements ConfigurationUpgrade, PostConstruct {
         // v3 uses logging.properties to configure the logging facility.
         // move all log-service elements to logging.properties
         final LogService logService = config.getLogService();
-
-        // check if null and exit
-        if (logService == null)
-         {
+        if (logService == null) {
             return;
-        // get a copy of the logging.properties file
         }
 
+        createLoggingPropertiesFileIfMissing();
+        final Map<String, String> properties = collectMigratableProperties(logService);
+
+        try {
+            ConfigSupport.apply(c -> {
+                try {
+                    logConfig.updateLoggingProperties(properties);
+                } catch (IOException e) {
+                    LOG.log(ERROR, "Failure while upgrading log-service. Could not update logging.properties file.", e);
+                }
+                c.setLogService(null);
+                return null;
+            }, config);
+        } catch (TransactionFailure e) {
+            throw new RuntimeException("Failure while upgrading log-service", e);
+        }
+    }
+
+    private void createLoggingPropertiesFileIfMissing() {
         try {
             RepositoryConfig rc = new RepositoryConfig();
             String configDir = rc.getRepositoryRoot() + File.separator + rc.getRepositoryName() + File.separator + rc.getInstanceName()
@@ -86,44 +104,74 @@ public class UpgradeLogging implements ConfigurationUpgrade, PostConstruct {
             if (!dest.exists()) {
                 FileUtils.copy(src, dest);
             }
-
         } catch (IOException e) {
             LOG.log(ERROR, "Failure while upgrading log-service. Could not create logging.properties file.", e);
         }
+    }
 
-        try {
-            //Get the logLevels
-            ModuleLogLevels mll = logService.getModuleLogLevels();
-
-            Map<String, String> logLevels = mll.getAllLogLevels();
-            String file = logService.getFile();
-            String instanceRoot = System.getProperty(INSTANCE_ROOT.getSystemPropertyName());
-            if (file.contains(instanceRoot)) {
-                file = file.replace(instanceRoot, "${" + INSTANCE_ROOT.getSystemPropertyName() + "}");
-            }
-            logLevels.put("file", file);
-            logLevels.put("use-system-logging", logService.getUseSystemLogging());
-            //this can have multiple values so need to add
-            logLevels.put("log-handler", logService.getLogHandler());
-            logLevels.put("log-filter", logService.getLogFilter());
-            logLevels.put("log-to-console", logService.getLogToConsole());
-            logLevels.put("log-rotation-limit-in-bytes", logService.getLogRotationLimitInBytes());
-            logLevels.put("log-rotation-timelimit-in-minutes", logService.getLogRotationTimelimitInMinutes());
-            logLevels.put("alarms", logService.getAlarms());
-            logLevels.put("retain-error-statistics-for-hours", logService.getRetainErrorStatisticsForHours());
-            final Map<String, String> m = new HashMap<>(logLevels);
-
-            ConfigSupport.apply(c -> {
-                try {
-                    logConfig.updateLoggingProperties(m);
-                    c.setLogService(null);
-                } catch (IOException e) {
-                    LOG.log(ERROR, "Failure while upgrading log-service. Could not update logging.properties file.", e);
-                }
-                return null;
-            }, config);
-        } catch (TransactionFailure e) {
-            throw new RuntimeException("Failure while upgrading log-service", e);
+    /**
+     * Collects the log-service settings that still have a counterpart in logging.properties,
+     * keyed by their legacy domain.xml name so that {@link LoggingConfigImpl} translates them.
+     *
+     * <p>Everything else is dropped. Attributes such as {@code alarms}, {@code use-system-logging},
+     * {@code log-filter}, {@code log-to-console} and {@code retain-error-statistics-for-hours},
+     * and the module log levels removed after v2, have no counterpart, and used to be written
+     * into logging.properties verbatim as keys nothing ever reads.
+     */
+    private Map<String, String> collectMigratableProperties(LogService logService) {
+        final Map<String, String> legacy = new HashMap<>();
+        final ModuleLogLevels moduleLogLevels = logService.getModuleLogLevels();
+        if (moduleLogLevels != null) {
+            legacy.putAll(moduleLogLevels.getAllLogLevels());
         }
+        legacy.put(LoggingXMLNames.file, toInstanceRootRelative(logService.getFile()));
+        legacy.put(LoggingXMLNames.logRotationLimitInBytes, logService.getLogRotationLimitInBytes());
+        legacy.put(LoggingXMLNames.logRotationTimelimitInMinutes, logService.getLogRotationTimelimitInMinutes());
+
+        final Map<String, String> properties = new HashMap<>();
+        for (Entry<String, String> entry : legacy.entrySet()) {
+            if (entry.getValue() != null && LoggingXMLNames.xmltoPropsMap.containsKey(entry.getKey())) {
+                properties.put(entry.getKey(), entry.getValue());
+            }
+        }
+        addCustomLogHandler(properties, logService.getLogHandler());
+        return properties;
+    }
+
+    /**
+     * The log-service log-handler named a handler <em>added</em> to the chain, while the key it
+     * translates to is the complete list of root handlers. Appending keeps the handlers
+     * configured by the logging.properties template, above all the GlassFishLogHandler writing
+     * the server log.
+     */
+    private void addCustomLogHandler(Map<String, String> properties, String logHandler) {
+        if (logHandler == null || logHandler.isBlank()) {
+            return;
+        }
+        final String rootHandlersKey = LoggingXMLNames.xmltoPropsMap.get(LoggingXMLNames.logHandler);
+        final String current;
+        try {
+            current = logConfig.getLoggingProperties().get(rootHandlersKey);
+        } catch (IOException e) {
+            LOG.log(ERROR, "Failure while upgrading log-service. Could not read logging.properties file,"
+                + " the " + logHandler + " handler has to be added manually.", e);
+            return;
+        }
+        if (current == null || current.isBlank()) {
+            properties.put(rootHandlersKey, logHandler);
+        } else if (Stream.of(current.split(",")).map(String::trim).noneMatch(logHandler::equals)) {
+            properties.put(rootHandlersKey, current + "," + logHandler);
+        }
+    }
+
+    private static String toInstanceRootRelative(String file) {
+        if (file == null) {
+            return null;
+        }
+        final String instanceRoot = System.getProperty(INSTANCE_ROOT.getSystemPropertyName());
+        if (instanceRoot == null || !file.contains(instanceRoot)) {
+            return file;
+        }
+        return file.replace(instanceRoot, "${" + INSTANCE_ROOT.getSystemPropertyName() + "}");
     }
 }

--- a/nucleus/admin/template/src/main/resources/config/domain.xml
+++ b/nucleus/admin/template/src/main/resources/config/domain.xml
@@ -233,9 +233,6 @@
              <!-- JSR 160  "system-jmx-connector" -->
              <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
          </admin-service>
-         <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
-             <module-log-levels />
-         </log-service>
          <security-service>
              <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
                  <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile" />

--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingConfigImpl.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingConfigImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -346,12 +346,9 @@ public class LoggingConfigImpl implements LoggingConfig, PostConstruct {
 
         while (e.hasMoreElements()) {
             String key = (String) e.nextElement();
-            // convert the name in domain.xml to the name in logging.properties if needed
-            if (LoggingXMLNames.xmltoPropsMap.get(key) != null) {
-                key = LoggingXMLNames.xmltoPropsMap.get(key);
-            }
-
-            m.put(key, props.getProperty(key));
+            // The value must be read under the key present in the file; only the reported
+            // name is converted from the legacy domain.xml name if needed.
+            m.put(LoggingXMLNames.xmltoPropsMap.getOrDefault(key, key), props.getProperty(key));
         }
         return m;
     }
@@ -369,12 +366,9 @@ public class LoggingConfigImpl implements LoggingConfig, PostConstruct {
         Enumeration<?> e = props.propertyNames();
         while (e.hasMoreElements()) {
             String key = (String) e.nextElement();
-            // convert the name in domain.xml to the name in logging.properties if needed
-            if (LoggingXMLNames.xmltoPropsMap.get(key) != null) {
-                key = LoggingXMLNames.xmltoPropsMap.get(key);
-            }
-
-            m.put(key, props.getProperty(key));
+            // The value must be read under the key present in the file; only the reported
+            // name is converted from the legacy domain.xml name if needed.
+            m.put(LoggingXMLNames.xmltoPropsMap.getOrDefault(key, key), props.getProperty(key));
         }
         return m;
     }
@@ -620,8 +614,8 @@ public class LoggingConfigImpl implements LoggingConfig, PostConstruct {
             String key = loggingPropertyNames.nextElement();
 
             // Convert the name in domain.xml to the name in logging.properties if needed
-            key = LoggingXMLNames.xmltoPropsMap.getOrDefault(key, key);
-            if (GlassFishLogHandlerProperty.OUTPUT_FILE.getPropertyFullName().equals(key)) {
+            String name = LoggingXMLNames.xmltoPropsMap.getOrDefault(key, key);
+            if (GlassFishLogHandlerProperty.OUTPUT_FILE.getPropertyFullName().equals(name)) {
                 return props.getProperty(key);
             }
         }
@@ -642,8 +636,8 @@ public class LoggingConfigImpl implements LoggingConfig, PostConstruct {
             String key = loggingPropertyNames.nextElement();
 
             // convert the name in domain.xml to the name in logging.properties if needed
-            key = LoggingXMLNames.xmltoPropsMap.getOrDefault(key, key);
-            if (GlassFishLogHandlerProperty.OUTPUT_FILE.getPropertyFullName().equals(key)) {
+            String name = LoggingXMLNames.xmltoPropsMap.getOrDefault(key, key);
+            if (GlassFishLogHandlerProperty.OUTPUT_FILE.getPropertyFullName().equals(name)) {
                 return props.getProperty(key);
             }
         }
@@ -672,11 +666,10 @@ public class LoggingConfigImpl implements LoggingConfig, PostConstruct {
         Enumeration<?> e = propsLoggingTemplate.propertyNames();
         while (e.hasMoreElements()) {
             String key = (String) e.nextElement();
-            // convert the name in domain.xml to the name in logging.properties if needed
-            if (LoggingXMLNames.xmltoPropsMap.get(key) != null) {
-                key = LoggingXMLNames.xmltoPropsMap.get(key);
-            }
-            m.put(key, propsLoggingTemplate.getProperty(key));
+            // The value must be read under the key present in the file; only the reported
+            // name is converted from the legacy domain.xml name if needed.
+            m.put(LoggingXMLNames.xmltoPropsMap.getOrDefault(key, key),
+                propsLoggingTemplate.getProperty(key));
         }
         return m;
     }

--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingXMLNames.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingXMLNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -75,6 +75,13 @@ public class LoggingXMLNames {
 
     private static final String LEVEL = ".level";
 
+    /**
+     * {@link LogDomains#DOMAIN_ROOT} is a logger name <em>prefix</em> and already ends with
+     * a dot, so it must not be concatenated with {@link #LEVEL} directly.
+     */
+    private static final String DOMAIN_ROOT_LOGGER
+        = LogDomains.DOMAIN_ROOT.substring(0, LogDomains.DOMAIN_ROOT.length() - 1);
+
     /** Mapping of the names used in domain.xml to the names used in logging.properties */
     public static final Map<String, String> xmltoPropsMap = Map.ofEntries(
         entry(logHandler, KEY_ROOT_HANDLERS.getPropertyName()),
@@ -86,7 +93,7 @@ public class LoggingXMLNames {
         entry(logRotationLimitInBytes, ROTATION_LIMIT_SIZE.getPropertyFullName()),
         entry(logRotationTimelimitInMinutes, ROTATION_LIMIT_TIME.getPropertyFullName()),
 
-        entry(root, LogDomains.DOMAIN_ROOT + LEVEL),
+        entry(root, DOMAIN_ROOT_LOGGER + LEVEL),
         entry(server, LogDomains.SERVER_LOGGER + LEVEL),
         entry(ejbcontainer, LogDomains.EJB_LOGGER + LEVEL),
         entry(cmpcontainer, LogDomains.CMP_LOGGER + LEVEL),

--- a/nucleus/common/common-util/src/test/java/com/sun/common/util/logging/LoggingXMLNamesTest.java
+++ b/nucleus/common/common-util/src/test/java/com/sun/common/util/logging/LoggingXMLNamesTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.common.util.logging;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * The legacy {@code domain.xml} names are still accepted by {@code set-log-levels} and
+ * {@code set-log-attributes}, so the keys they translate to must be usable in
+ * {@code logging.properties}.
+ */
+public class LoggingXMLNamesTest {
+
+    /**
+     * {@code LogDomains.DOMAIN_ROOT} already ends with a dot, so concatenating it with
+     * {@code ".level"} used to produce {@code jakarta..level} - a property for a logger
+     * literally named {@code jakarta.}, which configures nothing.
+     */
+    @Test
+    public void rootMapsToTheDomainRootLoggerLevel() {
+        assertEquals("jakarta.level", LoggingXMLNames.xmltoPropsMap.get(LoggingXMLNames.root));
+    }
+
+    @Test
+    public void noMappedKeyContainsAnEmptyNameSegment() {
+        for (Map.Entry<String, String> entry : LoggingXMLNames.xmltoPropsMap.entrySet()) {
+            String key = entry.getValue();
+            assertFalse(key.contains(".."),
+                () -> entry.getKey() + " maps to '" + key + "', which has an empty name segment");
+            assertFalse(key.startsWith(".") || key.endsWith("."),
+                () -> entry.getKey() + " maps to '" + key + "', which starts or ends with a dot");
+        }
+    }
+}


### PR DESCRIPTION
Logging has been configured through `logging.properties` since v3, but `domain.xml` still carries leftovers from the `<log-service>` era. This is the uncontroversial part of #24060: nothing user-facing is removed, and the config beans stay so that existing `domain.xml` files still parse and the v2 upgrade path keeps working.

### Stop writing `<log-service>` into new domains

Nothing reads the element at runtime any more:

- `MiniXmlParser.parseConfig()` has no `log-service` branch; the launcher resolves the server log from the `GlassFishLogHandler` output file property in `logging.properties`.
- `WebContainer` takes the server log path from `ServerLogFileManager.getCurrentLogFile()`.
- The only remaining `Config.getLogService()` callers are `Config.addIndex()`, which tolerates `null`, and the two upgrade services.

Yet both `domain.xml` templates wrote it into `default-config`, advertising a `log-rotation-limit-in-bytes` that has no effect — while `UpgradeLogging` exists precisely to delete the element from domains being upgraded. `server-config` has not carried it for a while; `default-config` now matches.

### Fix the legacy name translation

`LoggingXMLNames.xmltoPropsMap` translates the v2 `domain.xml` names that `set-log-levels` and `set-log-attributes` still accept. Two defects:

`LogDomains.DOMAIN_ROOT` is a logger name *prefix* ending with a dot, so concatenating it with `".level"` produced `jakarta..level` — a property for a logger literally named `jakarta.`. `asadmin set-log-levels root=FINE` configured nothing. It now maps to `jakarta.level`, the key the shipped `logging.properties` already uses. Same family as #26179.

`LoggingConfigImpl` translated a key read from `logging.properties` and then looked the value up under the *translated* name, which by definition is not the name present in the file. Any legacy key surviving in a file yielded a `null` value from `getLoggingProperties()` and `getDefaultLoggingProperties()`, and made `getLoggingFileDetails()` return `null` instead of the configured `server.log` path.

### Stop the upgrade from polluting `logging.properties`

`UpgradeLogging` pushed every `log-service` attribute and every module log level through `LoggingConfigImpl`, which writes any name it cannot translate verbatim. A domain upgraded from v2 gained about a dozen meaningless lines: `alarms`, `use-system-logging`, `log-filter`, `log-to-console`, `retain-error-statistics-for-hours`, and the module levels dropped after v2 (`verifier`, `connector`, `synchronization`, `node-agent`, `self-management`, `group-management-services`, `management-event`) — all of which default to a non-null value. Only settings with a counterpart are migrated now.

`log-handler` named a handler *added* to the chain, but the key it translates to is the complete list of root handlers, so migrating it replaced them — dropping the `GlassFishLogHandler` that writes the server log. It is appended instead.

A `<log-service>` without a `<module-log-levels>` child threw an NPE out of the upgrade, as did one without a `file` attribute; both are optional.

### Virtual server without `log-file`

`VirtualServer.getLogFile()` declared a default of `${com.sun.aas.instanceRoot}/logs/server.log`, so the config bean reported a log file for every virtual server even though no `domain.xml` has carried the attribute for years. `WebContainer` feeds that into `VirtualServer.setLogFile()`, which starts a virtual-server-specific `FileLoggerHandler` whenever the value differs from the server log.

The two agree in a default domain, so nothing happened there. Relocate the server log, though:

```
asadmin set-log-attributes org.glassfish.main.jul.handler.GlassFishLogHandler.file=/var/log/glassfish/server.log
```

and the phantom default no longer matches — the web container opens a second handler writing into `${com.sun.aas.instanceRoot}/logs/server.log`, the file the administrator just moved away from. This is derived from the code path, not reproduced on a running server.

The attribute is optional now, and `setLogFile()` compares against the server log path when it is not set. A virtual server without `log-file` stays attached to the server log wherever that log currently is; one that sets `log-file` behaves as before.

### Not in this PR

Left for a follow-up, since they need a maintainer decision:

- Deleting the `LogService` / `ModuleLogLevels` config beans, `NodeAgent.getLogService()`, `DefaultConfigUpgrade.LogServiceConfigCode` and `UpgradeLogging` itself. That breaks `asadmin get/set` on `configs.config.*.log-service.*` and drops the v2 to v3 logging migration.
- Removing `virtual-server@log-file` outright — attribute, admin console field, and the `devtests/web/virtualServerLogFile` devtest. That is a feature removal, not a cleanup.
- `DefaultConfigUpgrade` creates `<log-service>` while `UpgradeLogging` removes it, and `DomainXml.upgrade()` iterates the upgrade services without explicit ordering.

### Testing

`LoggingXMLNamesTest` is new and fails on `main` (`expected: <jakarta.level> but was: <jakarta..level>`). Green locally: `common-util` 108, `config-api` 89, `server-mgmt` 73, `launcher` 9, `web-glue` 2. Both templates verified well-formed.

Refs #24060

🤖 Generated with [Claude Code](https://claude.com/claude-code)
