### PR TITLE
Rewritten Jenkinsfile - based on Jenkinsfile in 9.0 branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,72 +15,200 @@
 * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 */
 
+// See:
+// https://hub.docker.com/r/eclipsecbi/jiro-agent-basic-ubuntu/tags
+// https://github.com/jenkinsci/kubernetes-plugin/blob/master/README.md
+// https://kubernetes.io/docs/concepts/workloads/pods/#working-with-pods
+// https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
+
+// These limits are collected from logs:
+// maximum cpu usage per Pod is 8300m
+// maximum cpu usage per Container is 8
+// maximum cpu usage is 44800m
+
 def mvnVersion = '3.9.16'
 def javaVersion = '21'
-def jdkTool = "temurin-jdk${javaVersion}-latest"
-def mvnTool = "apache-maven-${mvnVersion}"
 
-def mvnContainerCfg = """
+def podYamlTemplate = """
 apiVersion: v1
 kind: Pod
 spec:
+  nodeSelector:
+    kubernetes.io/os: "linux"
   containers:
-  - name: maven
+  - name: jnlp
+    imagePullPolicy: IfNotPresent
+    tty: true
+    workingDir: "/home/jenkins/agent"
+    env:
+    - name: "JENKINS_REMOTING_JAVA_OPTS"
+      value: "-showversion -XshowSettings:vm -Xmx256m -Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true -Dorg.jenkinsci.plugins.gitclient.CliGitAPIImpl.useSETSID=true"
+    - name: "JAVA_TOOL_OPTIONS"
+      value: ""
+    - name: "_JAVA_OPTIONS"
+      value: ""
+    - name: "OPENJ9_JAVA_OPTIONS"
+      value: "-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"
+    volumeMounts:
+    - name: "known-hosts"
+      mountPath: "/home/jenkins/.ssh"
+    resources:
+      limits:
+        memory: "768Mi"
+        cpu: "500m"
+      requests:
+        memory: "768Mi"
+        cpu: "500m"
+  - name: action
     image: maven:${mvnVersion}-eclipse-temurin-${javaVersion}
+    imagePullPolicy: IfNotPresent
     command:
     - cat
     tty: true
+    workingDir: /home/jenkins/agent
     env:
     - name: "HOME"
       value: "/home/jenkins"
     - name: "MAVEN_OPTS"
-      value: "-Duser.home=/home/jenkins -Xmx2g -Xss512k -XX:+UseG1GC -XX:+UseStringDeduplication"
+      value: "-Duser.home=/home/jenkins -Xms1g -Xmx2g -Xss512k -XX:MaxGCPauseMillis=200 -XX:+UseShenandoahGC -XX:+UseStringDeduplication"
     volumeMounts:
     - name: "jenkins-home"
       mountPath: "/home/jenkins"
+    - name: "known-hosts"
+      mountPath: "/home/jenkins/.ssh"
+    - name: "workspace-volume"
+      mountPath: "/home/jenkins/agent"
       readOnly: false
-    - name: maven-repo-shared-storage
-      mountPath: /home/jenkins/.m2/repository
-    - name: settings-xml
-      mountPath: /home/jenkins/.m2/settings.xml
-      subPath: settings.xml
+    - name: "m2-mvnd"
+      mountPath: "/home/jenkins/.m2/mvnd"
+    - name: "m2-dir"
+      mountPath: "/home/jenkins/.m2/toolchains.xml"
+      subPath: "toolchains.xml"
       readOnly: true
-    - name: settings-security-xml
-      mountPath: /home/jenkins/.m2/settings-security.xml
-      subPath: settings-security.xml
+    - name: "m2-dir"
+      mountPath: "/home/jenkins/.mavenrc"
+      subPath: ".mavenrc"
       readOnly: true
-    - name: maven-repo-local-storage
+    - name: "m2-wrapper"
+      mountPath: "/home/jenkins/.m2/wrapper"
+    - name: "maven-repo-shared-storage"
+      mountPath: "/home/jenkins/.m2/repository"
+    - name: "maven-repo-local-storage"
       mountPath: "/home/jenkins/.m2/repository/org/glassfish/main"
-    resources:
-      limits:
-        memory: "8Gi"
-        cpu: "5500m"
-      requests:
-        memory: "8Gi"
-        cpu: "5500m"
+    - name: "settings-xml"
+      mountPath: "/home/jenkins/.m2/settings.xml"
+      subPath: "settings.xml"
+      readOnly: true
+    - name: "settings-security-xml"
+      mountPath: "/home/jenkins/.m2/settings-security.xml"
+      subPath: "settings-security.xml"
+      readOnly: true
+    resources: VAR_RESOURCES
   volumes:
   - name: "jenkins-home"
     emptyDir:
       sizeLimit: "4Gi"
-  - name: maven-repo-shared-storage
+  - name: "known-hosts"
+    configMap:
+      name: "known-hosts"
+  - name: "tools"
     persistentVolumeClaim:
-      claimName: glassfish-maven-repo-storage
-  - name: settings-xml
+      claimName: "tools-claim-jiro-glassfish"
+      readOnly: true
+  - name: "m2-mvnd"
+    emptyDir: {}
+  - name: "m2-dir"
+    configMap:
+      name: "m2-dir"
+  - name: "m2-wrapper"
+    emptyDir: {}
+  - name: "m2-secret-dir"
     secret:
-      secretName: m2-secret-dir
-      items:
-      - key: settings.xml
-        path: settings.xml
-  - name: settings-security-xml
-    secret:
-      secretName: m2-secret-dir
-      items:
-      - key: settings-security.xml
-        path: settings-security.xml
-  - name: maven-repo-local-storage
+      secretName: "m2-secret-dir"
+  - name: "maven-repo-shared-storage"
+    persistentVolumeClaim:
+      claimName: "glassfish-maven-repo-storage"
+  - name: "maven-repo-local-storage"
     emptyDir:
       sizeLimit: "2Gi"
+  - name: "settings-xml"
+    secret:
+      secretName: "m2-secret-dir"
+      items:
+      - key: "settings.xml"
+        path: "settings.xml"
+  - name: "settings-security-xml"
+    secret:
+      secretName: "m2-secret-dir"
+      items:
+      - key: "settings-security.xml"
+        path: "settings-security.xml"
 """
+
+def antHeavyContainerCfg = podYamlTemplate.replace(
+"""    resources: VAR_RESOURCES
+""",
+"""    resources:
+      limits:
+        memory: "5.2Gi"
+        cpu: "3000m"
+      requests:
+        memory: "4.2Gi"
+        cpu: "3000m"
+"""
+)
+
+def antLightContainerCfg = podYamlTemplate.replace(
+"""    resources: VAR_RESOURCES
+""",
+"""    resources:
+      limits:
+        memory: "4Gi"
+        cpu: "2500m"
+      requests:
+        memory: "3Gi"
+        cpu: "2500m"
+"""
+)
+
+def mvnHeavyContainerCfg = podYamlTemplate.replace(
+"""    resources: VAR_RESOURCES
+""",
+"""    resources:
+      limits:
+        memory: "8Gi"
+        cpu: "7800m"
+      requests:
+        memory: "7Gi"
+        cpu: "7800m"
+"""
+)
+
+def mvnLightContainerCfg = podYamlTemplate.replace(
+"""    resources: VAR_RESOURCES
+""",
+"""    resources:
+      limits:
+        memory: "5Gi"
+        cpu: "4000m"
+      requests:
+        memory: "4Gi"
+        cpu: "4000m"
+"""
+)
+
+def tinyContainerCfg = podYamlTemplate.replace(
+"""    resources: VAR_RESOURCES
+""",
+"""    resources:
+      limits:
+        memory: "1Gi"
+        cpu: "1000m"
+      requests:
+        memory: "1Gi"
+        cpu: "1000m"
+"""
+)
 
 def dumpSysInfo() {
    sh """
@@ -103,69 +231,115 @@ def startVmstatLogging(String stageName) {
    sh """
    mkdir -p "${WORKSPACE}/logs"
    vmstat -t -w -a -y 10 > "${WORKSPACE}/logs/vmstat-${stageName}.log" 2>&1 & echo \$! > "${WORKSPACE}/vmstat.pid"
+
+   # Record this container's current and peak memory usage every 10 seconds.
+   # Prefer cgroup v2 and fall back to the cgroup v1 memory controller used by
+   # the current Eclipse CI workers. Values are bytes. If neither is available,
+   # skip the diagnostic without affecting the build.
+   if [ -r /sys/fs/cgroup/memory.current ]; then
+      memory_current=/sys/fs/cgroup/memory.current
+      memory_peak=/sys/fs/cgroup/memory.peak
+   elif [ -r /sys/fs/cgroup/memory/memory.usage_in_bytes ]; then
+      memory_current=/sys/fs/cgroup/memory/memory.usage_in_bytes
+      memory_peak=/sys/fs/cgroup/memory/memory.max_usage_in_bytes
+   else
+      memory_current=
+      memory_peak=
+   fi
+
+   if [ -n "\$memory_current" ]; then
+      (
+         printf '# current=%s peak=%s\n' "\$memory_current" "\$memory_peak"
+         while true; do
+            current=\$(cat "\$memory_current" 2>/dev/null || echo unavailable)
+            if [ -n "\$memory_peak" ] && [ -r "\$memory_peak" ]; then
+               peak=\$(cat "\$memory_peak" 2>/dev/null || echo unavailable)
+            else
+               peak=unavailable
+            fi
+            printf '%s memory.current=%s memory.peak=%s\n' "\$(date '+%Y-%m-%dT%H:%M:%S%z')" "\$current" "\$peak"
+            sleep 10
+         done
+      ) > "${WORKSPACE}/logs/cgroup-memory-${stageName}.log" 2>&1 &
+      echo \$! > "${WORKSPACE}/cgroup-memory.pid"
+   fi
    """
 }
 
 def stopVmstatLogging() {
    sh """
-   if [ -f "${WORKSPACE}/vmstat.pid" ]; then
-      pkill -F "${WORKSPACE}/vmstat.pid" || true
-      rm -f "${WORKSPACE}/vmstat.pid"
-   fi
+   for pidfile in vmstat.pid cgroup-memory.pid; do
+      if [ -f "${WORKSPACE}/\$pidfile" ]; then
+         pkill -F "${WORKSPACE}/\$pidfile" || true
+         rm -f "${WORKSPACE}/\$pidfile"
+      fi
+   done
    df -h || true
    """
    archiveArtifacts artifacts: "logs/*", allowEmptyArchive: true
 }
 
-def generateAntPodTemplate(job) {
+def generateAntPod(job, label) {
    return {
-      node {
-         stage("${job}") {
-            try {
-               startVmstatLogging("ant-${job}")
-               unstash 'maven-repo'
-               unstash 'appserv-tests'
-               timeout(time: 4, unit: 'HOURS') {
-                  withAnt(installation: 'apache-ant-latest') {
-                     dumpSysInfo()
-                     sh '''
-                     mkdir -p ${WORKSPACE}/appserver/tests
-                     tar -xvf ${BUNDLES_DIR}/maven-repo.tar.gz --overwrite -m -p -C /home/jenkins/.m2/repository
-                     tar -xvf ${BUNDLES_DIR}/appserv-tests.tar.gz -C ${WORKSPACE}
-                     '''
-                     sh """
-                     ./runtests.sh ${job}
-                     """
+      retry(count: 30, conditions: [kubernetesAgent(), nonresumable()]) {
+         node("${label}") {
+            stage("${job}") {
+               try {
+                  container('action') {
+                     script {
+                        try {
+                           startVmstatLogging("ant-${job}")
+                           unstash 'maven-repo'
+                           unstash 'appserv-tests'
+                           timeout(time: 1, unit: 'HOURS') {
+                              withAnt(installation: 'apache-ant-latest') {
+                                 dumpSysInfo()
+                                 sh '''
+                                 # Mandatory requirement -> fail fast if not available.
+                                 export BUNDLES_DIR="${WORKSPACE}/bundles"
+                                 ant -version
+                                 mvn -version
+                                 mkdir -p ${WORKSPACE}/appserver/tests
+                                 tar -xzf ${BUNDLES_DIR}/maven-repo.tar.gz --overwrite -m -p -C /home/jenkins/.m2/repository
+                                 tar -xzf ${BUNDLES_DIR}/appserv-tests.tar.gz -C ${WORKSPACE}
+                                 '''
+                                 sh """
+                                 export BUNDLES_DIR="\${WORKSPACE}/bundles"
+                                 ./runtests.sh ${job}
+                                 """
+                              }
+                           }
+                        } finally {
+                           stopVmstatLogging()
+                        }
+                     }
                   }
+               } finally {
+                  archiveArtifacts artifacts: "${job}-results.tar.gz", allowEmptyArchive: true
+                  junit testResults: 'results/junitreports/*.xml', allowEmptyResults: true, stdioRetention: 'FAILED'
                }
-            } finally {
-               stopVmstatLogging()
-               archiveArtifacts artifacts: "${job}-results.tar.gz"
-               junit testResults: 'results/junitreports/*.xml', allowEmptyResults: true, stdioRetention: 'FAILED'
             }
          }
       }
    }
 }
 
-def generateMvnTestPodTemplate(job, nodeCfg) {
+def generateMvnTestPod(job, label) {
    return {
-      podTemplate(
-         inheritFrom: 'basic',
-         yaml: nodeCfg
-      ) {
-         node(POD_LABEL) {
+      retry(count: 30, conditions: [kubernetesAgent(), nonresumable()]) {
+         node("${label}") {
             stage("${job}") {
                try {
-                  checkout scm
-                  container('maven') {
+                  container('action') {
                      script {
                         try {
                            startVmstatLogging("mvn-${job}")
-                           dumpSysInfo()
+                           unstash 'git'
                            unstash 'maven-repo'
-                           timeout(time: 4, unit: 'HOURS') {
+                           timeout(time: 1, unit: 'HOURS') {
+                              dumpSysInfo()
                               sh '''
+                              git reset --hard
                               tar -xzf ${BUNDLES_DIR}/maven-repo.tar.gz --overwrite -m -p -C /home/jenkins/.m2/repository
                               '''
                               sh """
@@ -190,70 +364,62 @@ def generateMvnTestPodTemplate(job, nodeCfg) {
    }
 }
 
-def ant_connector_jobs = [
-    "connector_group_1",
-    "connector_group_2",
-    "connector_group_3",
-    "connector_group_4"
+def ant_heavy_jobs = [
+    "connector_group_4",
+    "naming_all",
+    "ql_gf_full_profile_all"
 ]
-def ant_di_jobs = [
+
+// Slow jobs first
+def ant_light_jobs = [
+    "webservice_all",
+    "ejb_group_3",
+    "connector_group_1",
+    "deployment_all",
+    "security_all",
+    "web_jsp",
     "cdi_all",
     "ejb_group_1",
     "ejb_group_2",
-    "ejb_group_3",
-    "ejb_group_embedded"
-]
-def ant_db_jobs = [
+    "ejb_group_embedded",
+    "connector_group_2",
+    "connector_group_3",
     "jdbc_group1",
-    "jdbc_group2",
-    "jdbc_group3",
-    "jdbc_group4",
     "jdbc_group5",
-    "persistence_all"
-]
-def ant_other_jobs = [
-    "ql_gf_full_profile_all",
+    "jdbc_group4",
+    "jdbc_group3",
+    "jdbc_group2",
+    "persistence_all",
     "ql_gf_web_profile_all",
-    "web_jsp",
-    "batch_all",
-    "naming_all",
-    "deployment_all",
-    "security_all",
-    "webservice_all"
+    "batch_all"
 ]
+
 def mvn_jobs = [
     "admin-tests-parent",
     "application-tests",
     "embedded-tests"
 ]
 
-def parallelStagesMapAntConnectors = ant_connector_jobs.collectEntries {
-   ["${it}": generateAntPodTemplate(it)]
+def parallelStagesMapAntHeavy = ant_heavy_jobs.collectEntries {
+   ["${it}": generateAntPod(it, "ant-shared-pod-heavy")]
 }
-def parallelStagesMapAntDi = ant_di_jobs.collectEntries {
-   ["${it}": generateAntPodTemplate(it)]
-}
-def parallelStagesMapAntDb = ant_db_jobs.collectEntries {
-   ["${it}": generateAntPodTemplate(it)]
-}
-def parallelStagesMapAnt = ant_other_jobs.collectEntries {
-   ["${it}": generateAntPodTemplate(it)]
+def parallelStagesMapAntLight = ant_light_jobs.collectEntries {
+   ["${it}": generateAntPod(it, "ant-shared-pod-light")]
 }
 def parallelStagesMapMvn = mvn_jobs.collectEntries {
-   ["${it}": generateMvnTestPodTemplate(it, mvnContainerCfg)]
+   ["${it}": generateMvnTestPod(it, "maven-shared-pod-light")]
 }
 
 pipeline {
-
-   agent {
-      kubernetes {
-         inheritFrom "basic"
-         yaml mvnContainerCfg
-      }
-   }
-
+   // Do not hold one large Maven pod for the lifetime of the Pipeline.
+   // Prepare/Build and main-tests each get their own stage-scoped Maven pod,
+   // so Kubernetes can reclaim each pod's reservation as soon as that work
+   // is complete.
+   agent none
    environment {
-      BUNDLES_DIR = "${WORKSPACE}/bundles"
+      // Keep this relative because there is no pipeline-wide WORKSPACE when
+      // using agent none. Each pod gets the same bundles/ layout after unstash.
+      BUNDLES_DIR = "bundles"
       PORT_ADMIN=4848
       PORT_HTTP=8080
       PORT_HTTPS=8181
@@ -263,22 +429,17 @@ pipeline {
       // numToKeepStr - we need to know if it is changing.
       // artifactNumToKeepStr - they are quite large, so we keep just the last products.
       buildDiscarder(logRotator(numToKeepStr: '1', artifactNumToKeepStr: '1'))
-
-      // Any failure will cause interruption of other running steps
+      // Any failure will cause interruption of other running steps.
+      // Dynamic Kubernetes-agent infrastructure failures are retried inside each branch first.
       parallelsAlwaysFailFast()
-
       // to allow re-running a test stage, preserves just stashes of the most recent build
       preserveStashes()
-
       // issue related to default 'implicit' checkout, disable it
       skipDefaultCheckout()
-
       // abort pipeline if previous stage is unstable
       skipStagesAfterUnstable()
-
       // show timestamps in logs
       timestamps()
-
       // global timeout, abort after 6 hours
       timeout(time: 8, unit: 'HOURS')
    }
@@ -291,81 +452,95 @@ pipeline {
             }
          }
       }
-      stage('Check Changes') {
-         steps {
-            checkout scm
-            container('maven') {
-               script {
-                  // Default: run tests
-                  env.SKIP_TESTS = "false"
-
-                  // Only check for docs-only changes in PR builds
-                  if (env.CHANGE_TARGET) {
-                     echo "PR build detected, checking if only docs changed..."
-
-                     def relevantChanges = sh(
-                        script: '''
-                           (git diff --exit-code --name-only origin/${CHANGE_TARGET}...HEAD && echo "all") | sed '/^docs[/]/d'
-                        ''',
-                        returnStdout: true
-                     ).trim()
-
-
-                     if (relevantChanges == "") {
-                        env.SKIP_TESTS = "true"
-                        echo "✓ Only docs/ changes detected - tests will be skipped"
-                     } else {
-                        echo "✗ Relevant changes detected - tests will run"
+      // Check Changes and Build deliberately share one pod. The pod is
+      // released immediately after Build.
+      stage('Prepare') {
+         agent {
+            kubernetes {
+               label 'maven-shared-pod-heavy'
+               instanceCap 3
+               yaml mvnHeavyContainerCfg
+            }
+         }
+         stages {
+            stage('Check Changes') {
+               steps {
+                  checkout scm
+                  container('action') {
+                     script {
+                        // Default: run tests
+                        env.SKIP_TESTS = "false"
+                        // Only check for docs-only changes in PR builds
+                        if (env.CHANGE_TARGET) {
+                           echo "PR build detected, checking if only docs changed..."
+                           def relevantChanges = sh(
+                              script: '''
+                              (git diff --exit-code --name-only origin/${CHANGE_TARGET}...HEAD && echo "all") | sed '/^docs[/]/d'
+                              ''',
+                              returnStdout: true
+                           ).trim()
+                           if (relevantChanges == "") {
+                              env.SKIP_TESTS = "true"
+                              echo "✓ Only docs/ changes detected - tests will be skipped"
+                           } else {
+                              echo "✗ Relevant changes detected - tests will run"
+                           }
+                        } else {
+                           echo "Non-PR build - tests will always run"
+                        }
                      }
-                  } else {
-                     echo "Non-PR build - tests will always run"
+                     // Stash takes some time,
+                     stash includes: '.git/**/*', name: 'git', useDefaultExcludes: false
                   }
                }
             }
-         }
-      }
-      stage('Build') {
-         steps {
-            checkout scm
-            container('maven') {
-               script {
-                   try {
-                      startVmstatLogging('mvn-build')
-                      dumpSysInfo()
-                      timeout(time: 1, unit: 'HOURS') {
-                         sh '''
-                         # Validate the structure in all submodules (especially version ids)
-                         mvn -V -B -e -fae clean validate -Ptck,set-version-id,snapshots
-                         '''
-                         sh '''
-                         mvn -B -e install -Pfastest,ci,snapshots -T4C
-                         '''
-                         sh '''
-                         mvn -B -e clean
-                         mkdir -p ${BUNDLES_DIR}
-                         tar -c -C ${WORKSPACE} runtests.sh appserver/tests/common_test.sh appserver/tests/gftest.sh appserver/tests/appserv-tests appserver/tests/quicklook | gzip --fast > ${BUNDLES_DIR}/appserv-tests.tar.gz
-                         tar -c -C /home/jenkins/.m2/repository org/glassfish/main | gzip --fast > ${BUNDLES_DIR}/maven-repo.tar.gz
-                         '''
-                         sh '''
-                         # For easy access to built artifacts and using them elsewhere
-                         gfVersion="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
-                         mvn_copy="mvn -N org.apache.maven.plugins:maven-dependency-plugin:3.9.0:copy -DoutputDirectory=${BUNDLES_DIR}"
-                         ${mvn_copy} -Dartifact="org.glassfish.main.distributions:glassfish:${gfVersion}:zip"
-                         ${mvn_copy} -Dartifact="org.glassfish.main.distributions:web:${gfVersion}:zip"
-                         ${mvn_copy} -Dartifact="org.glassfish.main.extras:glassfish-embedded-all:${gfVersion}:jar"
-                         ${mvn_copy} -Dartifact="org.glassfish.main.extras:glassfish-embedded-web:${gfVersion}:jar"
-                         ls -la ${BUNDLES_DIR}
-                         '''
-                      }
-                   } finally {
-                      stopVmstatLogging()
-                   }
+            stage('Build') {
+               steps {
+                  container('action') {
+                     script {
+                        try {
+                           startVmstatLogging('mvn-build')
+                           timeout(time: 1, unit: 'HOURS') {
+                              dumpSysInfo()
+                              sh '''
+                              # Validate the structure in all submodules (especially version ids)
+                              mvn -B -e -fae clean validate -Ptck,set-version-id,snapshots
+                              '''
+// Makes build 6 minutes slower.
+//                              sh '''
+//                              mvn -B -e dependency:resolve-plugins -T8C
+//                              '''
+                              sh '''
+                              mvn -B -e install -Pfastest,ci,snapshots -T4C
+                              '''
+                              sh '''
+                              mvn -B -e clean
+                              mkdir -p ${BUNDLES_DIR}
+                              tar -c -C ${WORKSPACE} runtests.sh appserver/tests/common_test.sh appserver/tests/gftest.sh appserver/tests/appserv-tests appserver/tests/quicklook | gzip --fast > ${BUNDLES_DIR}/appserv-tests.tar.gz
+                              tar -c -C /home/jenkins/.m2/repository org/glassfish/main | gzip --fast > ${BUNDLES_DIR}/maven-repo.tar.gz
+                              '''
+                              sh '''
+                              # For easy access to built artifacts and using them elsewhere
+                              gfVersion="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
+                              mvn_copy="mvn -N dependency:copy -DoutputDirectory=${BUNDLES_DIR}"
+                              ${mvn_copy} -Dartifact="org.glassfish.main.distributions:glassfish:${gfVersion}:zip"
+                              ${mvn_copy} -Dartifact="org.glassfish.main.distributions:web:${gfVersion}:zip"
+                              ${mvn_copy} -Dartifact="org.glassfish.main.extras:glassfish-embedded-all:${gfVersion}:jar"
+                              ${mvn_copy} -Dartifact="org.glassfish.main.extras:glassfish-embedded-web:${gfVersion}:jar"
+                              ls -la ${BUNDLES_DIR}
+                              '''
+                           }
+                        } finally {
+                           stopVmstatLogging()
+                        }
+                     }
+                  }
+                  archiveArtifacts artifacts: 'bundles/*.zip', onlyIfSuccessful: true
+                  archiveArtifacts artifacts: 'bundles/*.jar', onlyIfSuccessful: true
+                  stash includes: 'bundles/appserv-tests.tar.gz', name: 'appserv-tests'
+                  stash includes: 'bundles/maven-repo.tar.gz', name: 'maven-repo'
                }
             }
-            archiveArtifacts artifacts: 'bundles/*.zip', onlyIfSuccessful: true
-            archiveArtifacts artifacts: 'bundles/*.jar', onlyIfSuccessful: true
-            stash includes: 'bundles/appserv-tests.tar.gz', name: 'appserv-tests'
-            stash includes: 'bundles/maven-repo.tar.gz', name: 'maven-repo'
          }
       }
 
@@ -374,15 +549,28 @@ pipeline {
             environment name: 'SKIP_TESTS', value: 'false'
          }
          parallel {
-            stage('main-tests') {
+            stage('MainTests') {
+               agent {
+                  kubernetes {
+                     retries 60
+                     label 'maven-shared-pod-heavy'
+                     instanceCap 3
+                     yaml mvnHeavyContainerCfg
+                  }
+               }
                steps {
-                  checkout scm
-                  container('maven') {
+                  container('action') {
                      script {
                         try {
                            startVmstatLogging('main-tests')
-                           dumpSysInfo()
+                           unstash 'git'
+                           unstash 'maven-repo'
                            timeout(time: 4, unit: 'HOURS') {
+                              dumpSysInfo()
+                              sh '''
+                              git reset --hard
+                              tar -xzf ${BUNDLES_DIR}/maven-repo.tar.gz --overwrite -m -p -C /home/jenkins/.m2/repository
+                              '''
                               sh '''
                               mvn -B -e clean verify -Pqa,ci,ci-main-tests,snapshots
                               '''
@@ -403,66 +591,66 @@ pipeline {
                   }
                }
             }
-            stage('itests') {
+            stage('ITests') {
                steps {
                   script {
-                     parallel parallelStagesMapMvn
+                     podTemplate(
+                        name: 'maven-shared-pod-light',
+                        label: 'maven-shared-pod-light',
+                        instanceCap: 3,
+                        slaveConnectTimeout: 60,
+                        yaml: mvnLightContainerCfg
+                     ) {
+                        parallel parallelStagesMapMvn
+                     }
                   }
                }
             }
-            stage('ant-connector') {
-               tools {
-                  jdk "${jdkTool}"
-                  maven "${mvnTool}"
-               }
+            stage('Ant-Heavy') {
                steps {
                   script {
-                     parallel parallelStagesMapAntConnectors
+                     podTemplate(
+                        name: 'ant-shared-pod-heavy',
+                        label: 'ant-shared-pod-heavy',
+                        instanceCap: 8,
+                        slaveConnectTimeout: 60,
+                        yaml: antHeavyContainerCfg
+                     ) {
+                        parallel parallelStagesMapAntHeavy
+                     }
                   }
                }
             }
-            stage('ant-db') {
-               tools {
-                  jdk "${jdkTool}"
-                  maven "${mvnTool}"
-               }
+            stage('Ant-Light') {
                steps {
                   script {
-                     parallel parallelStagesMapAntDb
-                  }
-               }
-            }
-            stage('ant-di') {
-               tools {
-                  jdk "${jdkTool}"
-                  maven "${mvnTool}"
-               }
-               steps {
-                  script {
-                     parallel parallelStagesMapAntDi
-                  }
-               }
-            }
-            stage('ant-other') {
-               tools {
-                  jdk "${jdkTool}"
-                  maven "${mvnTool}"
-               }
-               steps {
-                  script {
-                     parallel parallelStagesMapAnt
+                     podTemplate(
+                        name: 'ant-shared-pod-light',
+                        label: 'ant-shared-pod-light',
+                        instanceCap: 12,
+                        slaveConnectTimeout: 60,
+                        yaml: antLightContainerCfg
+                     ) {
+                        parallel parallelStagesMapAntLight
+                     }
                   }
                }
             }
          }
       }
-   }
 
-   post {
-      success {
-         // Overwrite stashes with empty content
-         stash includes: 'nothing', name: 'appserv-tests', allowEmpty: true
-         stash includes: 'nothing', name: 'maven-repo', allowEmpty: true
+      stage('Clear Stashes') {
+         agent {
+            kubernetes {
+               yaml tinyContainerCfg
+            }
+         }
+         steps {
+            // Overwrite stashes with empty content
+            stash includes: 'nothing', name: 'git', allowEmpty: true
+            stash includes: 'nothing', name: 'appserv-tests', allowEmpty: true
+            stash includes: 'nothing', name: 'maven-repo', allowEmpty: true
+         }
       }
    }
 }

--- a/appserver/tests/appserv-tests/devtests/cdi/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/cdi/run_test.sh
@@ -31,7 +31,7 @@ test_run(){
     ${S1AS_HOME}/bin/asadmin start-domain
     if [ "${JACOCO_ENABLED}" = "true" ]; then
         ${S1AS_HOME}/bin/asadmin create-jvm-options -javaagent\\:${BUNDLES_DIR}/org.jacoco.agent.jar=destfile=${WORKSPACE}/cdi.exec,append=true,includes=org/glassfish/**\\:com/sun/enterprise/**
-        ${S1AS_HOME}/bin/asadmin restart-domain
+        ${S1AS_HOME}/bin/asadmin restart-domain -o --timeout 60
     fi
     ${S1AS_HOME}/bin/asadmin start-database
 

--- a/appserver/tests/common_test.sh
+++ b/appserver/tests/common_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright (c) 2023 Contributors to the Eclipse Foundation. All rights reserved.
+# Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
 # Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -56,16 +56,18 @@ test_init(){
   printf "\n\n"
 }
 
-zip_test_results(){
+zip_test_results() {
   printf "\n%s \n\n" "===== ZIP THE TESTS RESULTS ====="
-  zip -r ${WORKSPACE}/results.zip ${WORKSPACE}/results > /dev/nul
+  jar -cf ${WORKSPACE}/results.zip -C ${WORKSPACE}/results .
 }
 
-unzip_test_resources(){
+unzip_test_resources() {
   printf "\n%s \n\n" "===== UNZIP TEST RESOURCES ====="
   for i in "${@}"; do
     if [[ ${i} == *.zip* ]]; then
-      unzip -qq -o ${i} -d ${WORKSPACE}
+      (cd ${WORKSPACE} && ${JAVA_HOME}/bin/jar -xf ${i} && chmod u+x $(find "${WORKSPACE}" -type f \
+      -name "asadmin" -o -name "nadmin" -o -name "startserv" -o -name "appclient" \
+      -o -name "wsimport" -o -name "wsgen" -o -name "*.sh"))
     else
       tar --overwrite -xf ${i}
     fi
@@ -77,15 +79,15 @@ copy_test_artifacts() {
   sleep 1; # imq sometimes stops after the domain
   printf "\n%s \n\n" "===== COPY TEST ARTIFACTS ====="
   mkdir -p ${WORKSPACE}/results/junitreports
-  
+
   tar -cf ${WORKSPACE}/results/domainArchive.tar.gz ${S1AS_HOME}/domains
-  
+
   cp ${S1AS_HOME}/domains/domain1/logs/server.log* ${WORKSPACE}/results/ || true
   cp ${TEST_RUN_LOG} ${WORKSPACE}/results/ || true
   cp ${APS_HOME}/test_results*.* ${WORKSPACE}/results/ || true
   cp `pwd`/*/*logs.zip ${WORKSPACE}/results/ || true
   cp `pwd`/*/*/*logs.zip ${WORKSPACE}/results/ || true
-  
+
   tar -caf ${WORKSPACE}/${1}-results.tar.gz ${WORKSPACE}/results || true
 }
 
@@ -160,7 +162,7 @@ change_junit_report_class_names(){
   if sed --version >/dev/null 2>&1; then
       ${SED} -i 's/\([a-zA-Z-]\w*\)\./\1-/g' ${WORKSPACE}/results/junitreports/*.xml
       ${SED} -i "s/\bclassname=\"/classname=\"${TEST_ID}./g" ${WORKSPACE}/results/junitreports/*.xml
-  else 
+  else
       ${SED} -i '' 's/\([a-zA-Z-]\w*\)\./\1-/g' ${WORKSPACE}/results/junitreports/*.xml
       ${SED} -i '' "s/\bclassname=\"/classname=\"${TEST_ID}./g" ${WORKSPACE}/results/junitreports/*.xml
   fi


### PR DESCRIPTION
### Original State

* Most jobs used base docker image from CBI team.
* Jobs were split to groups, but all was running in parallel
* Since June we had issues with Jenkins reliability, see https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/work_items/7610 ; issues sometimes went away, we reduced size of the history, tried to optimize Jenkinsfile, it always helped for a while but it broke again and again.
* The build in June took around 25 minutes. The nearly same build in September took around 40 minutes (depends on ordering of stages, which is decided by Jenkins, but it is always much slower than before).

### Story

* So finally @arjantijms lost his patience and found workarounds to avoid starving and failing builds in #26190 and #26191 . It smells by something what should not be necessary, because I believe it duplicates and hacks into meaning of life of Kubernetes, but it works. He also added some monitoring of peak memory usage including IO buffers. So I used most of it and just avoided the K8S stuff.

Then I started thinking ... why we create podTemplate for each job? Could it be possible to make it more simple? I also noticed that order of some configuration lines differ. And replacing numbers by different numbers confused me several times. After some maintenance and cleanup I took a paper and used some bash script to filter peak memory usages of every stage. Then I separated them to create configurations for pod templates... 

Finally I started tuning mem and cpu requests to find the best combination. We could probably try some simulations using measured data...

### Changes

* Current times are around 35 - 39 minutes, depends on ordering of stages, hardware chosen for nodes by k8s and also on the fact that the real hardware can be shared with other projects on the background.
* Refactored Pod/Node/PodTemplate configuration to make it more maintainable and logical.
  * The main agent is `none` now, so it doesn't allocate resource. That also mean it cannot run much. It is used just to orchestrate stages.
  * Actually, it also runs the first stage StopOld, so when the system is overloaded, this is still executed - so when you push to the same PR, this stage interrupts previous running builds of the same PR.
  * yaml configurations have now a template. I could also create a global podTemplate directly in the groovy script, but the syntax would look worse than this work with strings.
  * The only thing which changes in the template, is cpu and memory request for k8s.
  * Each pod template now uses own label and name, Jenkins uses labels to avoid starvation - if there is a capacity for small pods, they can run, while larger still wait. Yes, that means those large can starve for some time.
  * All pods now use the same docker image as a base, the Maven-Temurin docker image. That resolved also few older problems with PATH in Ant pod.
  * Instead of Ant and Maven container we have just the Action container as they were principialy the same.
  * Finally we have 5 yaml configurations and respectively 5 different pod definitions, each has own label. The usage of each label can be limited, but the limit is currently 20, which is much higher than CBI limit of 10 concurrent nodes.
  * Configuration templates are based on the cgroup mem peak usage monitoring as it was implemented in #26191
* G1GC for maven replaced by ShenandoahGC. On tight environments it has an advantage of returning unused memory to the system. I use it also with Eclipse IDE.
* GIT clone is not executed 5 times, but just once. Where needed, we stash/unstash it.
* 469 lines in main, 1066 in 9.0, 657 lines here.

### What limits we really have?

```
// Total GF project limit as of September 2026 is 13 sponsored resource packs (+1 is free), which means:
// cpu limit is 14 * 2000 = 28 000
// mem limit is 14 * 8 Gi = 112 Gi

// But ... these lines are collected from logs:
// maximum cpu usage per Pod is 8300m
// maximum cpu usage per Container is 8
// maximum cpu usage is 44800m
```
I guess I computed it wrong, so somebody explain me, please.

### Hardware Influence

Every stage can run on different hardware, these results are based just on our logs.

```
| CPU        | AMD EPYC 9255       | Intel Xeon Silver 4210R |
| CPU        | 96 threads <4.3 GHz | 40 threads <3.2 GHz     |
| BogoMIPS   | 6400                | 4800                    |
| Build      | ?                   | 7:31 - 8:12)            |
| Main Tests | 7:39                | 13:43 - 14:30           | (just mvn clean verify)
```
