### PR TITLE
Fix issues when set defaultWebModule for virtual server or delete a virtual server

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/WebAppHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/WebAppHandlers.java
@@ -35,6 +35,7 @@ import com.sun.jsftemplating.annotation.HandlerOutput;
 import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
 
 import java.net.URLEncoder;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,7 @@ import org.glassfish.admingui.common.util.DeployUtil;
 import org.glassfish.admingui.common.util.GuiUtil;
 import org.glassfish.admingui.common.util.RestResponse;
 import org.glassfish.admingui.common.util.RestUtil;
-
+import org.glassfish.admingui.common.util.TargetUtil;
 
 
 public class WebAppHandlers {
@@ -59,13 +60,13 @@ public class WebAppHandlers {
         input = {
             @HandlerInput(name = "endpoint", type = String.class, required = true),
             @HandlerInput(name = "vsName", type = String.class, required = true),
-            @HandlerInput(name = "instanceList", type=List.class, required=true)
+            @HandlerInput(name = "configName", type = String.class, required = true),
         })
     public static void ensureDefaultWebModule(HandlerContext handlerCtx) throws Exception {
         String endpoint = (String) handlerCtx.getInputValue("endpoint");
         String vsName = (String) handlerCtx.getInputValue("vsName");
         String encodedName = URLEncoder.encode(vsName, "UTF-8");
-        List<String> instanceList = (List) handlerCtx.getInputValue("instanceList");
+        String configName = (String) handlerCtx.getInputValue("configName");
 
         Map vsAttrs = RestUtil.getAttributesMap(endpoint + "/" + encodedName);
         String webModule= (String) vsAttrs.get("defaultWebModule");
@@ -76,11 +77,27 @@ public class WebAppHandlers {
         if (index != -1){
             appName=webModule.substring(0, index);
         }
+        String encodedAppName = URLEncoder.encode(appName, "UTF-8");
+        List clusters = TargetUtil.getClusters();
+        String clusterEndpoint = GuiUtil.getSessionValue("REST_URL") + "/clusters/cluster/";
         String serverEndPoint = GuiUtil.getSessionValue("REST_URL") + "/servers/server/";
-        for (String serverName : instanceList) {
-            String encodedAppName = URLEncoder.encode(appName, "UTF-8");
-            String encodedServerName = URLEncoder.encode(serverName, "UTF-8");
-            String apprefEndpoint = serverEndPoint + encodedServerName + "/application-ref/" + encodedAppName;
+        List<String> appTargets = DeployUtil.getApplicationTarget(appName, "application-ref");
+        List<String> reloadTargets = new ArrayList<>();
+        for (String targetName : appTargets) {
+            String encodedTargetName = URLEncoder.encode(targetName, "UTF-8");
+            String endpointUrl;
+            if (clusters.contains(targetName)) {
+                endpointUrl = clusterEndpoint + encodedTargetName;
+            } else {
+                endpointUrl = serverEndPoint + encodedTargetName;
+            }
+            String targetConfigName = (String) RestUtil.getAttributesMap(endpointUrl).get("configRef");
+            if (!configName.equals(targetConfigName)) {
+                // should skip the targets those not using the target config
+                continue;
+            }
+
+            String apprefEndpoint = endpointUrl + "/application-ref/" + encodedAppName;
             Map apprefAttrs = RestUtil.getAttributesMap(apprefEndpoint);
             String vsStr = (String) apprefAttrs.get("virtualServers");
             //Add to the vs list of this application-ref, then restart the app.
@@ -101,10 +118,10 @@ public class WebAppHandlers {
                 GuiUtil.handleError(handlerCtx, GuiUtil.getMessage("msg.error.checkLog"));
                 return;
             }
-            List targets = new ArrayList();
-            targets.add("domain");
-            DeployUtil.reloadApplication(appName, targets , handlerCtx);
+            // add the current server to the reload target
+            reloadTargets.add(encodedTargetName);
         }
+        DeployUtil.reloadApplication(appName, reloadTargets , handlerCtx);
    }
 
 

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/WebAppHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/WebAppHandlers.java
@@ -35,7 +35,6 @@ import com.sun.jsftemplating.annotation.HandlerOutput;
 import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
 
 import java.net.URLEncoder;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -78,6 +77,7 @@ public class WebAppHandlers {
             appName=webModule.substring(0, index);
         }
         String encodedAppName = URLEncoder.encode(appName, "UTF-8");
+        // both clusters and standalone instances should be handled.
         List clusters = TargetUtil.getClusters();
         String clusterEndpoint = GuiUtil.getSessionValue("REST_URL") + "/clusters/cluster/";
         String serverEndPoint = GuiUtil.getSessionValue("REST_URL") + "/servers/server/";
@@ -129,37 +129,44 @@ public class WebAppHandlers {
    //This handler is called after user deleted one more more VS from the VS table.
    //We need to go through all the application-ref to see if the VS specified still exist.  If it doesn't, we need to
    //remove that from the vs list.
-   @Handler(id = "checkVsOfAppRef")
+   @Handler(id = "checkVsOfAppRef",
+        input = {
+            @HandlerInput(name = "configName", type = String.class, required = true),
+        })
    public static void checkVsOfAppRef(HandlerContext handlerCtx) throws Exception{
+       String configName = (String) handlerCtx.getInputValue("configName");
        String configUrl = GuiUtil.getSessionValue("REST_URL") + "/configs/config/";
-       List configs = new ArrayList(RestUtil.getChildMap(configUrl).keySet());
-       ArrayList vsList = new ArrayList();
-       for (Object cfgName : configs) {
-           String vsUrl = configUrl + cfgName + "/http-service/virtual-server";
-           List vsNames = new ArrayList(RestUtil.getChildMap(vsUrl).keySet());
-           for (Object str : vsNames) {
-               if (!vsList.contains(str))
-                   vsList.add(str);
+       // only get vs of the current config
+       List<String> vsList = new ArrayList<>(RestUtil.getChildMap(configUrl + configName + "/http-service/virtual-server").keySet());
+
+       // both clusters and server instances should be handled.
+       String clusterEndpoint = GuiUtil.getSessionValue("REST_URL") + "/clusters/cluster/";
+       String serverEndpoint = GuiUtil.getSessionValue("REST_URL") + "/servers/server/";
+       List clusters = TargetUtil.getClusters();
+       List targets = TargetUtil.getInstances();
+       targets.addAll(clusters);
+       for (Object targetName : targets) {
+           String endpoint;
+           if (clusters.contains(targetName)) {
+               endpoint = clusterEndpoint + targetName;
+           } else {
+               endpoint = serverEndpoint + targetName;
            }
-       }
-       List servers = new ArrayList(RestUtil.getChildMap(GuiUtil.getSessionValue("REST_URL") + "/servers/server").keySet());
-       for (Object svrName : servers) {
-           String serverEndpoint = GuiUtil.getSessionValue("REST_URL") + "/servers/server/" + svrName;
-           List appRefs = new ArrayList(RestUtil.getChildMap(serverEndpoint + "/application-ref").keySet());
+           String targetConfigName = (String) RestUtil.getAttributesMap(endpoint).get("configRef");
+           if (!configName.equals(targetConfigName)) {
+               // should skip the targets those not using the target config
+               continue;
+           }
+           List appRefs = new ArrayList(RestUtil.getChildMap(endpoint + "/application-ref").keySet());
            for (Object appRef : appRefs) {
-               String apprefEndpoint = serverEndpoint + "/application-ref/" + appRef;
+               String apprefEndpoint = endpoint + "/application-ref/" + appRef;
                Map apprefAttrs = RestUtil.getAttributesMap(apprefEndpoint);
-               String vsStr = (String) apprefAttrs.get("VirtualServers");
+               String vsStr = (String) apprefAttrs.get("virtualServers");
                List<String> lvsList = GuiUtil.parseStringList(vsStr, ",");
-               boolean changed = false;
-               for(String oneVs: lvsList ){
-                   if (! vsList.contains(oneVs)){
-                       changed = true;
-                       continue;
-                   }
-               }
-               if (changed){
-                   apprefAttrs.put("VirtualServers", vsStr);
+               if (lvsList.removeIf(oneVs -> !vsList.contains(oneVs))){
+                   // remove the non-exist vs
+                   vsStr = String.join(",", lvsList);
+                   apprefAttrs.put("virtualServers", vsStr);
                    RestResponse response = RestUtil.sendUpdateRequest(apprefEndpoint, apprefAttrs, null, null, null);
                    if (!response.isSuccess()) {
                        GuiUtil.getLogger().severe("Update virtual server failed.  parent=" + apprefEndpoint + "; attrsMap =" + apprefAttrs);

--- a/appserver/admingui/web/src/main/resources/configuration/virtualServerButtons.inc
+++ b/appserver/admingui/web/src/main/resources/configuration/virtualServerButtons.inc
@@ -36,7 +36,7 @@
                     if(#{pageSession.configName}=server-config){
                         listAdd(list="#{pageSession.instanceList}" value="server" index="0");
                     }
-                    gf.ensureDefaultWebModule(endpoint="#{pageSession.parentUrl}/#{pageSession.childType}",vsName="#{pageSession.valueMap['id']}",instanceList="#{pageSession.instanceList}");
+                    gf.ensureDefaultWebModule(endpoint="#{pageSession.parentUrl}/#{pageSession.childType}",vsName="#{pageSession.valueMap['id']}",configName="#{pageSession.configName}");
                     getUIComponent(clientId="$pageSession{propertyTableRowGroupId}", component=>$attribute{tableRowGroup});
                     getAllSingleMapRows(TableRowGroup="$attribute{tableRowGroup}",  Rows=>$attribute{newList});
                     removeEmptyProps(props="#{pageSession.tableList}" modifiedProps="#{pageSession.tableList}");
@@ -71,7 +71,7 @@
                     if(#{pageSession.configName}=server-config){
                         listAdd(list="#{pageSession.instanceList}" value="server" index="0");
                     }
-                    gf.ensureDefaultWebModule(endpoint="#{pageSession.selfUrl}",vsName="#{pageSession.valueMap['id']}",instanceList="#{pageSession.instanceList}");
+                    gf.ensureDefaultWebModule(endpoint="#{pageSession.selfUrl}",vsName="#{pageSession.valueMap['id']}",configName="#{pageSession.configName}");
                     getUIComponent(clientId="$pageSession{propertyTableRowGroupId}", component=>$attribute{tableRowGroup});
                     getAllSingleMapRows(TableRowGroup="$attribute{tableRowGroup}",  Rows=>$attribute{newList});
                     removeEmptyProps(props="#{pageSession.tableList}" modifiedProps="#{pageSession.tableList}");

--- a/appserver/admingui/web/src/main/resources/configuration/virtualServers.jsf
+++ b/appserver/admingui/web/src/main/resources/configuration/virtualServers.jsf
@@ -45,7 +45,7 @@
         setPageSessionAttribute(key="editLink" value="#{request.contextPath}/web/configuration/virtualServerEdit.jsf?configName=#{configName}");
         setPageSessionAttribute(key="tableTitle" value="$resource{i18n_web.vs.TableTitle}");
         setPageSessionAttribute(key="additionalDeleteHandler" value="checkVsOfAppRef");
-        setPageSessionAttribute(key="additionalDeleteHandlerArgs" value="");
+        setPageSessionAttribute(key="additionalDeleteHandlerArgs" value="configName:%23{configName}");
     />
     </event>
 "    <script type="text/javascript">admingui.nav.selectTreeNodeById(admingui.nav.TREE_ID+":configurations:#{pageSession.encodedConfigName}:virtualServers");</script>


### PR DESCRIPTION
When set `defaultWebModule` using Admin Console, error occurs.

This is because `WebAppHandlers.ensureDefaultWebModule` not only handle with the config currently being edited.
For example, `a-web-app` targeting the clusters or standalone instances referencing configuration `a-config`.
those clusters or standalone instances not referencing `a-config` apparently not having `a-web-app` as `application-ref`, causing failures when updating `virtualServers` attribute on those `application-ref`.

And a wrong target ('domain') is given when calling `DeployUtil.reloadApplication(..)`, this would definitely fail unless a cluster or instance happened to have the same name as `domain`.

Further more, I think it also ought to update the `application-ref` of associated clusters. The original process only handle with instances.

Similarly, the problem (not considering config being edited and clusters) also appears when invoking additional handler (`checkVsOfAppRef`) after delete a virtual server.