### PR TITLE
Upgrade Helidon from 4.5.1 to 4.5.4

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -75,7 +75,7 @@
 
         <!-- MicroProfile Config -->
         <microprofile.config-api.version>3.1.1</microprofile.config-api.version>
-        <helidon-config.version>4.5.1</helidon-config.version>
+        <helidon-config.version>4.5.4</helidon-config.version>
 
 
         <!-- MicroProfile Health -->


### PR DESCRIPTION
Potentially fixes CVEs in Helidon, but I think all of them are related to Helidon's HTTP stack which GlassFish doesn't use

Release notes:

* https://github.com/helidon-io/helidon/releases#release-4.5.4
* https://github.com/helidon-io/helidon/releases#release-4.5.3
* https://github.com/helidon-io/helidon/releases#release-4.5.2