### PR TITLE
Measure HTTP session inactivity with a monotonic clock

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/StandardSession.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -65,6 +66,9 @@ import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.util.Enumerator;
 
 import static com.sun.logging.LogCleanerUtil.neutralizeForLog;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Standard implementation of the <b>Session</b> interface. This object is serializable, so that it can be stored in
@@ -89,6 +93,11 @@ public class StandardSession implements HttpSession, Session, Serializable {
     private static final Logger log = LogFacade.getLogger();
 
     private static final ResourceBundle rb = log.getResourceBundle();
+
+    /**
+     * Largest distance from the current time accepted by {@link #toNanoTime(long)}.
+     */
+    private static final long MAX_CLOCK_SHIFT_MILLIS = NANOSECONDS.toMillis(Long.MAX_VALUE / 4);
 
     // ----------------------------------------------------------- Constructors
 
@@ -267,6 +276,13 @@ public class StandardSession implements HttpSession, Session, Serializable {
     protected long thisAccessedTime = creationTime;
 
     /**
+     * {@link System#nanoTime()} of the current access, used to measure inactivity so that system clock changes neither
+     * shorten nor extend the session. NOTE: This value is not included in the serialized version of this object; it is
+     * derived from {@link #thisAccessedTime} when the session is deserialized.
+     */
+    protected transient volatile long thisAccessedNanos = System.nanoTime();
+
+    /**
      * The session version, incremented and used by in-memory-replicating session managers
      */
     protected AtomicLong version = new AtomicLong(-1);
@@ -316,6 +332,7 @@ public class StandardSession implements HttpSession, Session, Serializable {
         this.creationTime = time;
         this.lastAccessedTime = time;
         this.thisAccessedTime = time;
+        this.thisAccessedNanos = toNanoTime(time);
 
     }
 
@@ -653,6 +670,7 @@ public class StandardSession implements HttpSession, Session, Serializable {
     public void access() {
         this.lastAccessedTime = this.thisAccessedTime;
         this.thisAccessedTime = System.currentTimeMillis();
+        this.thisAccessedNanos = System.nanoTime();
 
         evaluateIfValid();
     }
@@ -937,14 +955,23 @@ public class StandardSession implements HttpSession, Session, Serializable {
      */
     @Override
     public boolean hasExpired() {
-
-        if (maxInactiveInterval >= 0 && (System.currentTimeMillis() - thisAccessedTime >= maxInactiveInterval * 1000L)) {
-            return true;
-        } else {
-            return false;
-        }
+        return maxInactiveInterval >= 0 && System.nanoTime() - thisAccessedNanos >= SECONDS.toNanos(maxInactiveInterval);
     }
     // END SJSAS 6329289
+
+    /**
+     * Converts a time in milliseconds since the epoch to the corresponding {@link System#nanoTime()} value. The distance
+     * from the current time is bounded, so that the nanosecond arithmetic in {@link #hasExpired()} cannot overflow.
+     *
+     * @param timeMillis time in milliseconds since the epoch
+     * @return the corresponding {@link System#nanoTime()} value
+     */
+    static long toNanoTime(long timeMillis) {
+        final long nowMillis = System.currentTimeMillis();
+        final long boundedMillis = Math.max(nowMillis - MAX_CLOCK_SHIFT_MILLIS,
+            Math.min(nowMillis + MAX_CLOCK_SHIFT_MILLIS, timeMillis));
+        return System.nanoTime() - MILLISECONDS.toNanos(nowMillis - boundedMillis);
+    }
 
     /**
      * Increments the version number
@@ -1708,6 +1735,7 @@ public class StandardSession implements HttpSession, Session, Serializable {
         isNew = ((Boolean) stream.readObject()).booleanValue();
         isValid = ((Boolean) stream.readObject()).booleanValue();
         thisAccessedTime = ((Long) stream.readObject()).longValue();
+        thisAccessedNanos = toNanoTime(thisAccessedTime);
         /*
          * SJSWS 6371339 principal = null; // Transient only // setId((String) stream.readObject()); id = (String)
          * stream.readObject();

--- a/appserver/web/web-core/src/test/java/org/apache/catalina/session/StandardSessionExpirationTest.java
+++ b/appserver/web/web-core/src/test/java/org/apache/catalina/session/StandardSessionExpirationTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.apache.catalina.session;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.apache.catalina.Manager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.replay;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Session inactivity is measured with {@link System#nanoTime()}, so system clock changes do not affect expiration.
+ */
+class StandardSessionExpirationTest {
+
+    private static final int INTERVAL_SECONDS = 60;
+    private static final long INTERVAL_MILLIS = SECONDS.toMillis(INTERVAL_SECONDS);
+    private static final long INTERVAL_NANOS = SECONDS.toNanos(INTERVAL_SECONDS);
+
+    private StandardSession session;
+
+    @BeforeEach
+    void createSession() {
+        final Manager manager = createNiceMock(Manager.class);
+        replay(manager);
+        session = new StandardSession(manager);
+        session.setCreationTime(System.currentTimeMillis());
+        session.setMaxInactiveInterval(INTERVAL_SECONDS);
+    }
+
+    @Test
+    void wallClockAccessTimeDoesNotAffectExpiration() {
+        // Equivalent to the system clock moving forward, then back, by an hour
+        session.thisAccessedTime -= HOURS.toMillis(1);
+        assertFalse(session.hasExpired());
+
+        session.thisAccessedTime += HOURS.toMillis(2);
+        assertFalse(session.hasExpired());
+    }
+
+    @Test
+    void expiresAfterInactivityEvenIfWallClockMovedBack() {
+        session.thisAccessedTime = System.currentTimeMillis() + HOURS.toMillis(1);
+        session.thisAccessedNanos = System.nanoTime() - INTERVAL_NANOS;
+        assertTrue(session.hasExpired());
+    }
+
+    @Test
+    void accessRestartsInactivity() {
+        session.thisAccessedNanos = System.nanoTime() - 2 * INTERVAL_NANOS;
+        assertTrue(session.hasExpired());
+
+        session.access();
+        assertFalse(session.hasExpired());
+    }
+
+    @Test
+    void negativeIntervalNeverExpires() {
+        session.setMaxInactiveInterval(-1);
+        session.thisAccessedNanos = System.nanoTime() - HOURS.toNanos(24);
+        assertFalse(session.hasExpired());
+    }
+
+    @Test
+    void setCreationTimeStartsInactivityAtThatTime() {
+        session.setCreationTime(System.currentTimeMillis() - 2 * INTERVAL_MILLIS);
+        assertTrue(session.hasExpired());
+
+        session.setCreationTime(System.currentTimeMillis());
+        assertFalse(session.hasExpired());
+    }
+
+    @Test
+    void deserializedSessionMeasuresInactivityFromStoredAccessTime() throws Exception {
+        session.setCreationTime(System.currentTimeMillis() - 2 * INTERVAL_MILLIS);
+        assertTrue(roundTrip(session).hasExpired());
+
+        session.setCreationTime(System.currentTimeMillis());
+        assertFalse(roundTrip(session).hasExpired());
+    }
+
+    @Test
+    void toNanoTimeDoesNotOverflow() {
+        final long now = System.nanoTime();
+        assertTrue(now - StandardSession.toNanoTime(Long.MIN_VALUE) > 0);
+        assertTrue(now - StandardSession.toNanoTime(-1L) > 0);
+        assertTrue(StandardSession.toNanoTime(Long.MAX_VALUE) - now > 0);
+    }
+
+    private static StandardSession roundTrip(StandardSession session) throws Exception {
+        final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(session);
+        }
+        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (StandardSession) in.readObject();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #26205

### Problem

`StandardSession.hasExpired()` compared `System.currentTimeMillis()` with `thisAccessedTime`, so a system clock step changed the session lifetime: moving the clock forward expired sessions early, moving it back kept them alive past `maxInactiveInterval`.

### Changes

- `StandardSession`: new `transient volatile long thisAccessedNanos`, set in `access()` and `setCreationTime()` and derived from `thisAccessedTime` in `readRemainingObject()`. `hasExpired()` compares it with `System.nanoTime()`.
- `thisAccessedTime` and `lastAccessedTime` are unchanged and remain wall-clock time, since they are serialized, replicated by web-ha and returned by `getLastAccessedTime()`. The serialized form does not change.
- `toNanoTime(long)` bounds the distance from the current time, so extreme values cannot overflow into a session that never expires.
- Not changed: `StoreBase.processExpires()` and the `PersistentManagerBase` idle swap/backup checks, because stored sessions only carry the wall-clock stamp.

On Linux `System.nanoTime()` is based on `CLOCK_MONOTONIC`, which does not advance while the host is suspended.

### Tests

New `StandardSessionExpirationTest` (7 tests): changes of the wall-clock stamp do not affect expiration, expiration after inactivity with the wall clock moved back, `access()` restarting inactivity, negative interval, `setCreationTime()`, serialization round trip, and the overflow bounds of `toNanoTime(long)`.

`mvn -pl appserver/web/web-core test` on JDK 21: 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
